### PR TITLE
Renamed master to main

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,7 +4,7 @@ on:
   push:
     # branches to consider in the event; optional, defaults to all
     branches:
-      - master
+      - main
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
Since (Github changing default branch name)[https://www.infoq.com/news/2020/10/github-main-branch/] from master to main a month ago, this repo's default branch is called main, and release-drafter, set to trigger on master, did not work. This PR should fix it. 