### PR TITLE
Add both master and main branches to workflows

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,6 +5,7 @@ on:
     # branches to consider in the event; optional, defaults to all
     branches:
       - main
+      - master
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
Since workflows from this repository are supposed to be copied and used elsewhere, even in many repositories where default branch is still called `master` it would be wise to target both `master` and `main` in the release-drafter workflow. 